### PR TITLE
Hotfix/backups

### DIFF
--- a/lib/packager.js
+++ b/lib/packager.js
@@ -24,16 +24,19 @@ function createVendorPackage(profileName, targets) {
 		})
 
 		fs.readdir(filePath, function(err, items) {
-			console.log(items);
-		 
-			for (var i=0; i<items.length; i++) {
-				console.log(items[i]);
-			}
-		});
+			console.log('BACKUPS ' + items)
 
-		fs.copy(filePath + '/backup.jpg', dirTrafficAd + '/backup.jpg', err => {
-			if (err) return console.error(err)
-			log('to_traffic backup.jpg success')
+			var item
+			for (var i = 0; i < items.length; i++) {
+				item = items[i]
+				console.log('Backups   ' + item)
+				if (item.indexOf('.jpg') > -1) {
+					fs.copy(filePath + '/' + item, dirTrafficAd + '/' + item, err => {
+						if (err) return console.error(err)
+						log('to_traffic backup success')
+					})
+				}
+			}
 		})
 	})
 }

--- a/lib/packager.js
+++ b/lib/packager.js
@@ -23,6 +23,14 @@ function createVendorPackage(profileName, targets) {
 			log('to_traffic index.html success')
 		})
 
+		fs.readdir(filePath, function(err, items) {
+			console.log(items);
+		 
+			for (var i=0; i<items.length; i++) {
+				console.log(items[i]);
+			}
+		});
+
 		fs.copy(filePath + '/backup.jpg', dirTrafficAd + '/backup.jpg', err => {
 			if (err) return console.error(err)
 			log('to_traffic backup.jpg success')


### PR DESCRIPTION
Fixed the Vendor Indexes plugin. It now scrubs the folder and moves all .jgp files to the 4-vendor folders which assures that any backup not specifically named backup.jpg will be copied over.